### PR TITLE
Draft: smaller fixes

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: create ansible inventory
   ansible.builtin.copy:
     dest: "{{ potos_basics_ansible_inventory }}"
-    content: "{{ potos_basics_hostname }} ansible_connection=local"
+    content: "{{ potos_basics_hostname.stdout }} ansible_connection=local"
     force: false
     owner: root
     group: root

--- a/templates/usr/local/bin/potos-ansible-pull.j2
+++ b/templates/usr/local/bin/potos-ansible-pull.j2
@@ -146,7 +146,7 @@ CheckToolAvailable /usr/bin/wall
     {{ potos_basics_ansible_workdir }} 2>&1 || die "Failed to checkout playbook repository"
 
 # Adjust ansible config with client
-/usr/bin/sed 's|/var/log/potos|{{ potos_basics_ansible_logdir }}|' {{ potos_basics_ansible_workdir }}/ansible.cfg
+/usr/bin/sed -i 's|/var/log/potos|{{ potos_basics_ansible_logdir }}|' {{ potos_basics_ansible_workdir }}/ansible.cfg
 
 # Run Ansible with custom ansible.cfg, use flock to prevent concurrent runs
 ANSIBLE_CONFIG={{ potos_basics_ansible_workdir }}/ansible.cfg

--- a/templates/usr/local/bin/potos-ansible-pull.j2
+++ b/templates/usr/local/bin/potos-ansible-pull.j2
@@ -163,6 +163,7 @@ exec {flockfd}</var/lock/{{ potos_basics_client_name | lower }}.lock
 source  {{ potos_basics_ansible_virtenvdir }}/bin/activate  || die "Failed activate virtualenv"
 pip3 install ansible-core=={{ potos_basics_ansible_version }} || die "Failed install ansible-core in virtualenv"
 
+cd /var/lib/{{ potos_basics_client_name }}/ansible
 ansible-playbook {% if potos_basics_ansible_vault_key_check.stat.exists %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}-i {{ potos_basics_ansible_inventory }} {{ potos_basics_ansible_workdir }}/prepare.yml -e "{{ potos_basics_ansible_runtype_var_name }}=$RUN_TYPE"
 ansible-playbook {% if potos_basics_ansible_vault_key_check.stat.exists %}--vault-password-file=/etc/potos/ansible_vault_key {% endif %}-i {{ potos_basics_ansible_inventory }} {{ potos_basics_ansible_workdir }}/playbook.yml -e "{{ potos_basics_ansible_runtype_var_name }}=$RUN_TYPE"
 


### PR DESCRIPTION
## Description

During development of my own client, I found a few minor bugs.

* Fixes #19: Brute force fix by explicit `cd /var/lib/{{potos_basics_client_name}}/ansible` before starting the playbooks
* Bug: `sed` does not change the file, but output it on stdout. Therefore, logs of hourly runs still did not work.
* The creation (only done when not present) of `/etc/ansible/inventory/{{potos_basics_client_name}}_inventory` was flawed: It containted the full registered hash and not just `stdout`.

## Dependencies

none