### PR TITLE
fix: parse RUN_TYPE correctly

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,8 @@ potos_basics_runtypes:
     on_calendar: 'hourly'
   - runtype: 'setup'
 
+potos_basics_ansible_runtype_var_name: "{{ potos_basics_client_name | lower }}_runtype"
+
 potos_basics_always_verbose: false
 
 potos_basics_on_error_additional_lines:

--- a/templates/usr/local/bin/potos-ansible-pull.j2
+++ b/templates/usr/local/bin/potos-ansible-pull.j2
@@ -82,9 +82,9 @@ while :; do
 {%- endif -%}
 {%- endfor -%}"
       else
-        RUN_TYPE=$OPTARG
+        RUN_TYPE=$2
       fi
-      shift
+      shift 2
       ;;
     --) # end of all options
       shift

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -15,6 +15,3 @@ potos_basics_packages:
 
 # Ansible version to be used
 potos_basics_ansible_version: "2.12.3"
-
-# Runtype variable name:
-potos_basics_ansible_runtype_var_name: "{{ potos_basics_client_name | lower }}_runtype"


### PR DESCRIPTION
## Description

I discovered during testing that the parsing for the runtype did not work, so always the default `daily` got executed.
Either we really use the bash builtin `while getopts` and then `$OPTARG` is defined or not.

In addition, it is currently not really possible to change the name of the runtype variable as this
is hardcoded in too many places. My personal workaround was to configure the variable
in my specs repo. Which did not work because it is currently set in `/vars/`. I moved this
setting to `/defaults/`, not configuration actually works.

But maybe it would be better just to hardcode it in `/vars/` to `potos_runtype`...

## Dependencies

none