### PR TITLE
fix: make ansible-galaxy work again with community.general

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -14,4 +14,4 @@ potos_basics_packages:
  - "bsdutils"            # wall
 
 # Ansible version to be used
-potos_basics_ansible_version: "2.12.3"
+potos_basics_ansible_version: "2.12.10"


### PR DESCRIPTION
## Description

I recently tried to install a client from an iso i created a few weeks ago and it failed with the error
messages as described e.g. [in this bug](https://github.com/ansible/awx/issues/14495)

## Dependencies

See [this MR](https://github.com/projectpotos/potos-iso-builder/pull/50/files) in the potos-iso-builder repo.